### PR TITLE
First port to synopsys ARC processors

### DIFF
--- a/tensorflow/lite/experimental/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/experimental/micro/tools/make/download_and_extract.sh
@@ -68,13 +68,18 @@ patch_kissfft() {
   echo "Finished patching kissfft"
 }
 
+build_embarc_mli() {
+  gmake -j 4 -C ${1}/lib/make TCF_FILE=${2}
+}
+
 # Main function handling the download, verify, extract, and patch process.
 download_and_extract() {
-  local usage="Usage: download_and_extract URL MD5 DIR [ACTION]"
+  local usage="Usage: download_and_extract URL MD5 DIR [ACTION] [ACTION_PARAM]"
   local url="${1:?${usage}}"
   local expected_md5="${2:?${usage}}"
   local dir="${3:?${usage}}"
   local action=${4}
+  local action_param1=${5}  # optional action parameter
   local tempdir=$(mktemp -d)
   local tempdir2=$(mktemp -d)
   local tempfile=${tempdir}/temp_file
@@ -136,10 +141,12 @@ download_and_extract() {
     patch_am_sdk ${dir}
   elif [[ ${action} == "patch_kissfft" ]]; then
     patch_kissfft ${dir}
+  elif [[ ${action} == "build_embarc_mli" ]]; then
+    build_embarc_mli ${dir} ${action_param1}
   elif [[ ${action} ]]; then
     echo "Unknown action '${action}'"
     exit 1
   fi
 }
 
-download_and_extract "$1" "$2" "$3" "$4"
+download_and_extract "$1" "$2" "$3" "$4" "$5"

--- a/tensorflow/lite/experimental/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/helper_functions.inc
@@ -73,6 +73,24 @@ $(PRJDIR)$(3)/$(1)/third_party/%: tensorflow/lite/experimental/micro/tools/make/
 	@mkdir -p $$(dir $$@)
 	@cp $$< $$@
 
+ifeq ($(TARGET_ARCH), arc)
+$(PRJDIR)$(3)/$(1)/Makefile: tensorflow/lite/experimental/micro/tools/make/templates/Makefile.tpl
+	@mkdir -p $$(dir $$@)
+	@sed -E 's#\%\{SRCS\}\%#$(4)#g' $$< | \
+	sed -E '1 i\CC = ccac\nCXX = ccac\nLD = ccac\n' | \
+	sed -E 's#\%\{EXECUTABLE\}\%#$(3).elf#g' | \
+	sed -E 's#\%\{LINKER_FLAGS\}\%#$(6)#g' | \
+	sed -E 's#\%\{CXX_FLAGS\}\%#$(7)#g' | \
+	sed -E 's#\%\{CC_FLAGS\}\%#$(8)#g' > $$@
+
+# Special rule to copy TCF in case the local filesystem file name has been defined
+ifneq ($(TCF_FILE_NAME), )
+$(PRJDIR)$(3)/$(1)/$(TCF_FILE_NAME): $(TCF_FILE)
+	@cp $$< $$@
+endif
+
+endif
+
 $(PRJDIR)$(3)/$(1)/%: tensorflow/lite/experimental/micro/tools/make/templates/%.tpl
 	@mkdir -p $$(dir $$@)
 	@sed -E 's#\%\{SRCS\}\%#$(4)#g' $$< | \
@@ -303,10 +321,12 @@ endef
 # generate the standalone project.
 define generate_microlite_projects
 $(call generate_project,make,$(MAKE_PROJECT_FILES),$(1),$(MICROLITE_CC_SRCS) $(THIRD_PARTY_CC_SRCS) $(2),$(MICROLITE_CC_HDRS) $(THIRD_PARTY_CC_HDRS) $(MICROLITE_TEST_HDRS) $(3),$(LDFLAGS) $(MICROLITE_LIBS),$(CXXFLAGS) $(GENERATED_PROJECT_INCLUDES), $(CCFLAGS) $(GENERATED_PROJECT_INCLUDES))
+ifneq ($(TARGET_ARCH), arc)
 $(call generate_project,mbed,$(MBED_PROJECT_FILES),$(1),$(MICROLITE_CC_SRCS) $(THIRD_PARTY_CC_SRCS) $(2),$(MICROLITE_CC_HDRS) $(THIRD_PARTY_CC_HDRS) $(MICROLITE_TEST_HDRS) $(3),$(MICROLITE_LIBS),$(CXXFLAGS),$(CCFLAGS))
 $(call generate_project,keil,$(KEIL_PROJECT_FILES),$(1),$(MICROLITE_CC_SRCS) $(THIRD_PARTY_CC_SRCS) $(2),$(MICROLITE_CC_HDRS) $(THIRD_PARTY_CC_HDRS) $(MICROLITE_TEST_HDRS) $(3),$(MICROLITE_LIBS),$(CXXFLAGS),$(CCFLAGS))
 $(call generate_arduino_project,$(ARDUINO_PROJECT_FILES),$(1),$(MICROLITE_CC_SRCS) $(THIRD_PARTY_CC_SRCS) $(2),$(MICROLITE_CC_HDRS) $(THIRD_PARTY_CC_HDRS) $(MICROLITE_TEST_HDRS) $(3),$(MICROLITE_LIBS),$(CXXFLAGS),$(CCFLAGS))
 $(call generate_esp_project,$(ESP_PROJECT_FILES),$(1),$(MICROLITE_CC_SRCS) $(THIRD_PARTY_CC_SRCS),$(MICROLITE_CC_HDRS) $(THIRD_PARTY_CC_HDRS) $(MICROLITE_TEST_HDRS),$(2),$(3),$(MICROLITE_LIBS),$(CXXFLAGS),$(CCFLAGS),$(PROJECT_INCLUDES))
+endif
 endef
 
 # Handles the details of generating a binary target, including specializing
@@ -347,10 +367,11 @@ endef
 # 2 - MD5 sum of archive, to check integrity. Use md5sum tool to generate.
 # 3 - Folder name to unpack library into, inside tf/l/x/m/t/downloads root.
 # 4 - Optional patching action, must match clause in download_and_extract.sh.
+# 5 - Optional patching action parameter
 # These arguments are packed into a single '!' separated string, so no element
 # can contain a '!'.
 define add_third_party_download
-THIRD_PARTY_DOWNLOADS += $(1)!$(2)!tensorflow/lite/experimental/micro/tools/make/downloads/$(3)!$(4)
+THIRD_PARTY_DOWNLOADS += $(1)!$(2)!tensorflow/lite/experimental/micro/tools/make/downloads/$(3)!$(4)!$(5)
 endef
 
 # Unpacks an entry in a list of strings created by add_third_party_download, and

--- a/tensorflow/lite/experimental/micro/tools/make/targets/arc_makefile.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/targets/arc_makefile.inc
@@ -1,0 +1,84 @@
+# Settings for arc processors
+ifeq ($(TARGET_ARCH), arc)
+  CC = ccac
+  CXX = ccac
+  LD = ccac
+
+ifneq ($(TCF_FILE), )
+  TARGET = $(basename $(notdir $(TCF_FILE)))
+else
+  TARGET = em7d_voice_audio
+  TCF_FILE = em7d_voice_audio 
+endif
+
+# The variable TCF_FILE_NAME stores the TCF file name (including .tcf extension), this variable is used later to add the option to the linker/compiler flags.
+# This condition also handles the case when the user/makefile specifies the configuration bundled with MWDT (usually without .tcf extension) and that doesn't require copying.
+ifneq (,$(findstring .tcf,$(TCF_FILE)))
+  TCF_FILE_NAME = $(notdir $(TCF_FILE))
+  THIRD_PARTY_CC_HDRS += $(TCF_FILE_NAME)
+else
+  TCF_FILE_NAME = $(TCF_FILE)
+endif
+
+  PLATFORM_FLAGS = -tcf=$(TCF_FILE_NAME) -Hnocopyr -O3 -Hpurge -Hcl -fslp-vectorize-aggressive -ffunction-sections -fdata-sections
+  PLATFORM_LDFLAGS = -tcf=$(TCF_FILE_NAME) -Hnocopyr -m -Hldopt=-Coutput=memory.map
+
+  CXXFLAGS += $(PLATFORM_FLAGS)
+  CXXFLAGS:=$(filter-out -std=c++11,$(CXXFLAGS))
+  CCFLAGS += $(PLATFORM_FLAGS)
+  LDFLAGS += $(PLATFORM_LDFLAGS)
+
+  MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))
+
+  USE_EMBARC_MLI ?= true
+
+ifeq ($(USE_EMBARC_MLI), true)
+  ALL_TAGS += arc
+
+ifeq ($(PRE_COMPILED_MLI),true)
+  $(eval $(call add_third_party_download,$(EMBARC_OSP_URL),$(EMBARC_OSP_MD5),embarc_osp,))
+
+  MLI_INCLUDE_FOLDER = embarc_osp/library/embarc_mli/include
+  MLI_LIB = third_party/embarc_osp/library/embarc_mli/lib/arcem9d/libmli_iotdk.a
+
+  THIRD_PARTY_CC_HDRS += \
+    third_party/embarc_osp/LICENSE
+else
+  MLI_LIB_DIR = embarc_mli_$(basename $(TCF_FILE_NAME))
+
+  $(eval $(call add_third_party_download,$(EMBARC_MLI_URL),$(EMBARC_MLI_MD5),$(MLI_LIB_DIR),build_embarc_mli,$(TCF_FILE)))
+
+  MLI_INCLUDE_FOLDER = $(MLI_LIB_DIR)/include
+  MLI_LIB = third_party/$(MLI_LIB_DIR)/bin/libmli.a
+  
+  THIRD_PARTY_CC_HDRS += \
+    third_party/$(MLI_LIB_DIR)/LICENSE
+endif
+
+  THIRD_PARTY_CC_HDRS += $(MLI_LIB)
+  MICROLITE_LIBS += $(MLI_LIB)
+
+  INCLUDES += \
+    -I$(MAKEFILE_DIR)/downloads/$(MLI_INCLUDE_FOLDER) \
+    -I$(MAKEFILE_DIR)/downloads/$(MLI_INCLUDE_FOLDER)/api
+
+  GENERATED_PROJECT_INCLUDES += \
+    -I. \
+    -I./third_party/$(MLI_INCLUDE_FOLDER) \
+    -I./third_party/$(MLI_INCLUDE_FOLDER)/api
+
+
+  THIRD_PARTY_CC_HDRS += \
+    third_party/$(MLI_INCLUDE_FOLDER)/mli_api.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/mli_config.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/mli_types.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/api/mli_helpers_api.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/api/mli_kernels_api.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/api/mli_krn_avepool_spec_api.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/api/mli_krn_conv2d_spec_api.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/api/mli_krn_depthwise_conv2d_spec_api.h \
+    third_party/$(MLI_INCLUDE_FOLDER)/api/mli_krn_maxpool_spec_api.h \
+
+endif # USE_EMBARC_MLI
+
+endif

--- a/tensorflow/lite/experimental/micro/tools/make/templates/Makefile.tpl
+++ b/tensorflow/lite/experimental/micro/tools/make/templates/Makefile.tpl
@@ -1,3 +1,5 @@
+RM = rm -f
+
 SRCS := \
 %{SRCS}%
 
@@ -19,3 +21,7 @@ LDFLAGS += %{LINKER_FLAGS}%
 	$(CXX) $(CXXFLAGS) -o $@ $(OBJS) $(LDFLAGS)
 
 all: %{EXECUTABLE}%
+
+clean:
+	-$(RM) $(OBJS)
+	-$(RM) %{EXECUTABLE}%

--- a/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
@@ -54,3 +54,9 @@ KISSFFT_MD5="438ba1fef5783cc5f5f201395cc477ca"
 
 PERSON_MODEL_URL := "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_grayscale_2019_11_07.zip"
 PERSON_MODEL_MD5 := "e6430de25aa92bcb807d07278a1b5b90"
+
+EMBARC_OSP_URL := "https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_osp/archive/embarc_mli.zip"
+EMBARC_OSP_MD5 := "9eaf7b3a1ed05872a03da9796672a776"
+
+EMBARC_MLI_URL := "https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_mli/archive/datatypes.zip"
+EMBARC_MLI_MD5 := "e2243f53c88ca3bedbb8cc8c3bb44053"


### PR DESCRIPTION
- add arc specific makefile include
- link mli lib
- Update makefile generator for TARGET_ARCH=arc
  In case TARGET_ARCH=arc: changing the makefile generator to add the CC/LD executables to the Makefile; diabling Mbed,Keil and Arduino projects generation, adding TCF_FILE variable support that also defines the TARGET string
- TCF file is copied to the project root directory to get rid of the absolute path
- adding .elf extension (ARC only); default TCF is ARC EM7D; clean target for project makefile template
- Linker output is redirected by the appropriate option
- Additn a suffix (TCF name) to the MLI directory name to support parallel project generation inside the same sources tree; using gmake to build MLI